### PR TITLE
Check for form keys with empty values

### DIFF
--- a/csr.py
+++ b/csr.py
@@ -36,9 +36,9 @@ class CsrGenerator(object):
 
         for field in fields:
             try:
-                # Remove empty values
+                # Check for keys with empty values
                 if form_values[field] == "":
-                    form_values.pop(field)
+                    raise KeyError
                 valid[field] = form_values[field]
             except KeyError:
                 if field not in optional:


### PR DESCRIPTION
The values returned from request.form are an `ImmutableMultiDict`
so we can't pop anything out. Raise a KeyError instead and allow
the exception handler to decide whether or not to reraise.