### PR TITLE
Add CRYPTOGRAPHY_DONT_BUILD_RUST env var for Rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM jazzdd/alpine-flask:python3
 LABEL maintainer="David Wittman"
 
-# Install deps before we add our project to cache this layer
-RUN apk add --no-cache gcc python3-dev musl-dev libffi-dev openssl openssl-dev
-
 ADD . /app/
 
-RUN pip install -r requirements.txt && \
+# Install deps before we add our project to cache this layer
+RUN apk add --no-cache \
+    gcc python3-dev musl-dev libffi-dev openssl openssl-dev && \
+    export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
+    pip install -r requirements.txt && \
     apk del gcc git python3-dev musl-dev libffi-dev openssl-dev


### PR DESCRIPTION
- Add `CRYPTOGRAPHY_DONT_BUILD_RUST=1` to avoid building crypto with Rust support.
- Optimize `Dockerfile` to reduce Docker layer.